### PR TITLE
Introduce amun inspection template

### DIFF
--- a/notebooks/templates/Amun Inspection Analysis Template.ipynb
+++ b/notebooks/templates/Amun Inspection Analysis Template.ipynb
@@ -1,0 +1,423 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amun Inspection Performance Analysis [Template]\n",
+    "\n",
+    "The purpose of this notebook is to have a reusable notebook that can be customized depending on the performance analysis that can be performed based on [Amun Service](https://github.com/thoth-station/amun-api) and using [Performance Indicators](https://github.com/thoth-station/performance)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Amun Inspections inputs\n",
+    "\n",
+    "**Software stacks and native dependencies**\n",
+    "\n",
+    "example:\n",
+    "\n",
+    "  * `AICoE TensorFlow` - `tensorflow==2.2.0` available on AICoE index (inspection identifier contains  `rhtf`)\n",
+    "  \n",
+    "**OS images**\n",
+    "\n",
+    "example:\n",
+    "\n",
+    "  * `rhel-8` \n",
+    "\n",
+    "**Python Interpreters**\n",
+    "\n",
+    "example:\n",
+    "\n",
+    "  * `3.6` \n",
+    "  \n",
+    "**Hardware**\n",
+    "\n",
+    "example:\n",
+    "\n",
+    "\n",
+    "### Performance indicators\n",
+    "Performance Indicators (PI) used for performance analysis:\n",
+    "\n",
+    "  * [matrix multiplication](https://github.com/thoth-station/performance/blob/master/tensorflow/matmul.py)\n",
+    "  * [convolution 1D](https://github.com/thoth-station/performance/blob/master/tensorflow/conv1d.py)\n",
+    "  * [convolution 2D](https://github.com/thoth-station/performance/blob/master/tensorflow/conv2d.py)\n",
+    "\n",
+    "Each performance indicator was run `x times` per inspection run (`batch size == x`), performance indicators reported median of inspections to be further compared.\n",
+    "\n",
+    "## Dataset content\n",
+    "\n",
+    "Inspection specification, build logs, job logs, hardware information of the node where the performance indicator was run and the actual inspection job result.\n",
+    "\n",
+    "No buildtime/runtime errors spotted with the tested stack.\n",
+    "\n",
+    "\n",
+    "# Analysis\n",
+    "\n",
+    "Results of performance are shown in terms of Elapsed time [ms].\n",
+    "\n",
+    "The analysis performed in this notebook are defined as:\n",
+    "\n",
+    "example:\n",
+    "\n",
+    "- Performance analysis across different Tf stacks (Python packages) (with/without optimized library e.g.MKL) (fixing Hardware, OS image, Python Interpreter, number of CPUs)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assign environment variables and import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: THOTH_DEPLOYMENT_NAME=ocp-stage\n",
+      "env: THOTH_CEPH_HOST=https://s3.upshift.redhat.com/\n",
+      "env: THOTH_CEPH_BUCKET=thoth\n",
+      "env: THOTH_CEPH_BUCKET_PREFIX=data\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env THOTH_DEPLOYMENT_NAME     ocp-stage\n",
+    "%env THOTH_CEPH_HOST           https://s3.upshift.redhat.com/\n",
+    "%env THOTH_CEPH_BUCKET         thoth\n",
+    "%env THOTH_CEPH_BUCKET_PREFIX  data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from thoth.report_processing.components.inspection import AmunInspections\n",
+    "from thoth.report_processing.components.inspection import AmunInspectionsSummary\n",
+    "from thoth.report_processing.components.inspection import AmunInspectionsStatistics\n",
+    "\n",
+    "inspection = AmunInspections()\n",
+    "inspection_runs_summary = AmunInspectionsSummary()\n",
+    "inspection_statistics = AmunInspectionsStatistics()\n",
+    "\n",
+    "import pandas as pd\n",
+    "pd.set_option('display.max_rows', 500)\n",
+    "pd.set_option('display.max_columns', 1000)\n",
+    "pd.set_option('display.width', 1500)\n",
+    "pd.options.plotting.backend = \"plotly\"  # Convert to matplotlib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract dataset if data are not retrieved from Ceph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FILE_NAME = \"dataset-name.zip\"\n",
+    "from thoth.report_processing.utils import extract_zip_file\n",
+    "extract_zip_file(FILE_NAME)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "inspections_identifiers = ['']  # List of identifiers for the analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve and process data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### from Ceph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspection_runs = inspection.aggregate_thoth_inspections_results(\n",
+    "    inspections_identifiers=inspections_identifiers,\n",
+    ")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### from local path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "current_path = Path.cwd()\n",
+    "\n",
+    "inspection_runs = inspection.aggregate_thoth_inspections_results(\n",
+    "    inspections_identifiers=inspections_identifiers,\n",
+    "    is_local=True,\n",
+    "    repo_path=current_path.joinpath(\"inspections\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "processed_inspection_runs, failed_inspection_runs = inspection.process_inspection_runs(\n",
+    "    inspection_runs,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspections_df = inspection.create_inspections_dataframe(\n",
+    "    processed_inspection_runs=processed_inspection_runs,\n",
+    "    include_statistics=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inspections_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspections summary report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results, _ = inspection_runs_summary.produce_summary_report(inspections_df=inspections_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hardware"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"hardware\"]['platform']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"hardware\"]['processor']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"hardware\"]['flags']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"hardware\"]['ncpus']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"hardware\"]['info']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Operating System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"base_image\"]['base_image']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"base_image\"]['number_cpus_run']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performance Indicator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"pi\"]['pi']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Software Stack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report_results[\"software_stack\"]['requirements_locked']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "python_packages_dataframe, python_packages_versions = inspection.create_python_package_df(inspections_df=inspections_df)\n",
+    "python_packages_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create final dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_dataframe = inspection.create_final_dataframe(\n",
+    "    inspections_df=inspections_df,\n",
+    "    include_statistics=True\n",
+    ")\n",
+    "final_dataframe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>


## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

Add a notebook template for Amun inspection that can be reused by anyone (humans or bots) parametrized with identifier (no default plots provided yet).
