### PR TITLE
Update pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,35 @@
 ---
 repos:
-  - repo: git://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.2.1
     hooks:
       - id: add-trailing-comma
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
-  - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
+  - repo: https://github.com/pycqa/pydocstyle.git
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.942
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -43,12 +37,12 @@ repos:
         additional_dependencies: [attrs~=19.3]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: '3.8.4'
+    rev: '3.9.2'
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"


### PR DESCRIPTION
## This Pull Request implements

This is to switch `pre-commit` configuration URLs from `git://` to `https://` (ref https://github.com/thoth-station/thoth-application/issues/2111).

Also taking the opportunity to de-duplicate and update versions.