### PR TITLE
Update the links to the Operate First public Ceph bucket

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,35 @@
 ---
 repos:
-  - repo: git://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v2.2.1
     hooks:
       - id: add-trailing-comma
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
-      - id: check-toml
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
-    hooks:
-      - id: trailing-whitespace
-      - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-added-large-files
+      - id: check-ast
       - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-docstring-first
       - id: check-json
+      - id: check-merge-conflict
       - id: check-symlinks
-      - id: detect-private-key
-      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
       - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
 
-  - repo: git://github.com/pycqa/pydocstyle.git
-    rev: 5.1.1
+  - repo: https://github.com/pycqa/pydocstyle.git
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.942
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'
@@ -43,12 +37,12 @@ repos:
         additional_dependencies: [attrs~=19.3]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://gitlab.com/PyCQA/flake8
-    rev: '3.8.4'
+    rev: '3.9.2'
     hooks:
       - id: flake8
         additional_dependencies: ['pep8-naming']

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
     context: aicoe-ci/prow/pre-commit
     spec:
       containers:
-        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.14.3
           command:
             - "pre-commit"
             - "run"

--- a/notebooks/thoth-performance-dataset/PerformanceTensorFlow2.1.0SoftwareStackCombinations.ipynb
+++ b/notebooks/thoth-performance-dataset/PerformanceTensorFlow2.1.0SoftwareStackCombinations.ipynb
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {

--- a/notebooks/thoth-performance-dataset/ThothPerformanceDataset.ipynb
+++ b/notebooks/thoth-performance-dataset/ThothPerformanceDataset.ipynb
@@ -65,7 +65,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {

--- a/notebooks/thoth-security-dataset/ThothSecurityDataset.ipynb
+++ b/notebooks/thoth-security-dataset/ThothSecurityDataset.ipynb
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {

--- a/notebooks/thoth-solver-dataset/ThothSolverDataset-v2.0.ipynb
+++ b/notebooks/thoth-solver-dataset/ThothSolverDataset-v2.0.ipynb
@@ -79,7 +79,7 @@
    "id": "99d49096-3572-4517-8d1e-5c96c99e064b",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {

--- a/notebooks/thoth-solver-dataset/ThothSolverDataset.ipynb
+++ b/notebooks/thoth-solver-dataset/ThothSolverDataset.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {

--- a/notebooks/thoth-solver-dataset/link-of-solver-and-invectio.ipynb
+++ b/notebooks/thoth-solver-dataset/link-of-solver-and-invectio.ipynb
@@ -21,7 +21,7 @@
    "id": "38459e78-3ecd-486a-a70e-e95b2b49bb20",
    "metadata": {},
    "source": [
-    "For more detail on the Operate First Ceph public bucket used here, visit https://github.com/operate-first/apps/blob/master/docs/odh/trino/access_public_bucket.md"
+    "For more detail on the Operate First Ceph public bucket used here, visit https://www.operate-first.cloud/apps/content/odh/trino/access_public_bucket.html"
    ]
   },
   {


### PR DESCRIPTION
Subject Says it all (SSIA).

The current link to the public/open ceph bucket docs in the notebooks does not work, this fixes the link.

I am not updating the references to credentials within the notebooks though - the link should be the place to go for people to get the current version of these I believe.